### PR TITLE
avoid segfault during `Context.path_close_subpath`

### DIFF
--- a/src/svgfill.cpp
+++ b/src/svgfill.cpp
@@ -119,7 +119,9 @@ public:
 		tag::coordinate::absolute) {}
 
 	void path_close_subpath() {
-		segments.back().push_back({ xy_, start_ });
+		if (enabled_at_ != -1) {
+			segments.back().push_back({ xy_, start_ });
+		}
 	}
 
 	void path_exit() {}


### PR DESCRIPTION
Added a check similar to `path_line_to` to avoid segfault accessing `segments.back()` in the case if `class_name` was initialized but current element doesn't have a correct class (see `void set(tag::attribute::class_, Str const & s)void set(tag::attribute::class_, Str const & s)`) and therefore `segments` is an empty vector and `vector.back()` then is UB.

Related - https://github.com/IfcOpenShell/IfcOpenShell/issues/4580