### PR TITLE
cmake - require libxml2 package explicitly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ endif()
 
 find_package(Boost)
 message(STATUS "Boost include files found in ${Boost_INCLUDE_DIRS}")
+find_package(LibXml2 REQUIRED)
 
 if(WASM_BUILD)
     set(CMAKE_FIND_ROOT_PATH "${CMAKE_FIND_ROOT_PATH_BACKUP}")


### PR DESCRIPTION
It was kind of checked in IfcOpenShell/CMakeLists.txt, but it wasn't checked if if IFCXML_SUPPORT wasn't set to ON. Adding to svgfill's cmake to make sure configuration won't skip this dependency.