### PR TITLE
Fix CMake 3.30 warning about CMP0167

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,9 @@ cmake_policy(SET CMP0074 NEW) # find_package() uses <PackageName>_ROOT variables
 if (POLICY CMP0144)
 cmake_policy(SET CMP0144 NEW) # find_package() uses upper-case <PACKAGENAME>_ROOT variables.
 endif()
+if(POLICY CMP0167) # 3.30 find_package(Boost) to use BoostConfig instead of FindBoost.
+    cmake_policy(SET CMP0167 OLD)
+endif()
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
Example warning:
```
CMake Warning (dev) at IfcOpenShell/src/svgfill/CMakeLists.txt:115 (find_package): Policy CMP0167 is not set: The FindBoost module is removed. Run "cmake --help-policy CMP0167" for policy details. Use the cmake_policy command to set the policy and suppress this warning.
```